### PR TITLE
Revisit previous Fart.css versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Run `deno fmt` to format the code.
 
 Run `deno lint` to lint the code.
 
+Run `deno check main.ts` to check the code.
+
 ---
 
 Developed with 🧪 [**@FartLabs**](https://github.com/FartLabs)

--- a/components/page_layout.tsx
+++ b/components/page_layout.tsx
@@ -48,8 +48,8 @@ export function PageLayout(props: PageLayoutProps) {
           <SCRIPT>
             {`document.addEventListener("DOMContentLoaded", function() {
                 const url = new URL(window.location.href);
-                console.log(url.searchParams);
-                // If url has search params, copy them over to Fart.css link.
+                const linkElement = document.head.querySelector('link[href="${fartCSS}"]');
+                linkElement.href = "https://css.fart.tools/fart.css" + url.search;
               });`}
           </SCRIPT>
         </BODY>

--- a/components/page_layout.tsx
+++ b/components/page_layout.tsx
@@ -44,6 +44,14 @@ export function PageLayout(props: PageLayoutProps) {
           {props.children?.join("") ?? ""}
           <PageBreak />
           <PageFoot />
+
+          <SCRIPT>
+            {`document.addEventListener("DOMContentLoaded", function() {
+                const url = new URL(window.location.href);
+                console.log(url.searchParams);
+                // If url has search params, copy them over to Fart.css link.
+              });`}
+          </SCRIPT>
         </BODY>
       </HTML>
     );
@@ -53,7 +61,10 @@ function Favicon() {
   return <LINK rel="icon" href="/fl-logo.png" />;
 }
 
+const fartCSS = "https://css.fart.tools/fart.css";
+
 const stylesheets = [
+  "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark-dimmed.min.css",
   "/tube-green.css",
   "/tube-purple.css",
   "/tube-yellow.css",
@@ -62,7 +73,7 @@ const stylesheets = [
   "/tube-orange.css",
   "/tube-blue.css",
   "/tube-empty.css",
-  "https://css.fart.tools/fart.css",
+  fartCSS,
   "/cubes.css",
   "/index.css",
 ];

--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,8 @@
   "tasks": {
     "generate": "deno run --allow-read --allow-write codegen/codegen.ts",
     "start": "deno run --allow-net --allow-read --allow-env --env main.ts generated",
-    "molt": "deno run -A jsr:@molt/cli -w"
+    "molt": "deno run -A jsr:@molt/cli -w",
+    "gs": "deno task generate && deno task start"
   },
   "fmt": {
     "exclude": ["generated"]


### PR DESCRIPTION
### Changes

- Adds the user's ability to revisit previous Fart.css versions on Fartlabs.org via URL search param.

| <https://fartlabs.org/?minimal> | <https://fartlabs.org/?halloween> |
| --- | --- |
| [![Default Fart.css version](https://github.com/user-attachments/assets/ef8bb56d-d41a-4003-8805-411ae9e3833e)](https://fartlabs.org/?minimal) | [![Halloween Fart.css version](https://github.com/user-attachments/assets/55bd7dbc-9e0f-466d-be1c-24fa8fc26b59)](https://fartlabs.org/?halloween) |