### PR TITLE
Blog post aliases

### DIFF
--- a/blog/mission.md
+++ b/blog/mission.md
@@ -6,6 +6,7 @@ authors:
     username: "EthanThatOneKid"
 topics: ["Community"]
 date: 2024-11-07
+aliases: ["about"]
 ---
 
 In today's world, software is crucial in everything we do. However, many

--- a/codegen/html.tsx
+++ b/codegen/html.tsx
@@ -1,10 +1,11 @@
 import { LandingPage } from "#/components/landing_page/mod.ts";
 import { PeoplePage } from "#/components/people_page/mod.ts";
-import { posts, topics } from "#/components/blog_page/data.ts";
+import { aliases, posts, topics } from "#/components/blog_page/data.ts";
 import { toTopicID } from "#/components/blog_page/posts.ts";
 import { BlogPage } from "#/components/blog_page/blog_page.tsx";
 import { BlogPostPage } from "#/components/blog_page/blog_post_page.tsx";
 import people from "#/static/people.json" with { type: "json" };
+import { PageRedirect } from "#/components/page_redirect.tsx";
 
 /**
  * generateHTMLSync generates the HTML files for the website synchronously.
@@ -37,6 +38,15 @@ export function generateHTMLSync(directory: string = "generated") {
     Deno.writeTextFileSync(
       `${directory}/${post.id}/index.html`,
       postPageHTML,
+    );
+  }
+
+  for (const [alias, destination] of aliases) {
+    const aliasPageHTML: string = <PageRedirect to={destination} />;
+    Deno.mkdirSync(`${directory}/${alias}`, { recursive: true });
+    Deno.writeTextFileSync(
+      `${directory}/${alias}/index.html`,
+      aliasPageHTML,
     );
   }
 }

--- a/components/blog_page/data.ts
+++ b/components/blog_page/data.ts
@@ -1,5 +1,11 @@
-import { getFeaturedPosts, getSortedTopics, readPostsSync } from "./posts.ts";
+import {
+  getAliases,
+  getFeaturedPosts,
+  getSortedTopics,
+  readPostsSync,
+} from "./posts.ts";
 
 export const posts = readPostsSync();
 export const featuredPosts = getFeaturedPosts(posts);
 export const topics = getSortedTopics(posts);
+export const aliases = getAliases(posts);

--- a/components/blog_page/posts.ts
+++ b/components/blog_page/posts.ts
@@ -114,6 +114,7 @@ export interface PostAttrs {
   authors: PostAuthor[];
   topics: string[];
   date: Date;
+  aliases?: string[];
 }
 
 /**
@@ -172,4 +173,26 @@ export function toTopicID(topic: string) {
  */
 export function getFeaturedPosts(posts: Post[], limit = 3): Post[] {
   return posts.toSorted(byPinnedDescending).slice(0, limit);
+}
+
+/**
+ * getAliases returns the aliases of the blog posts.
+ */
+export function getAliases(posts: Post[]): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const post of posts) {
+    if (post.attrs.aliases === undefined) {
+      continue;
+    }
+
+    for (const alias of post.attrs.aliases) {
+      if (aliases.has(alias)) {
+        throw new Error(`duplicate alias ${alias}`);
+      }
+
+      aliases.set(alias, `/${post.id}`);
+    }
+  }
+
+  return aliases;
 }

--- a/components/page_redirect.tsx
+++ b/components/page_redirect.tsx
@@ -1,0 +1,15 @@
+import { HEAD, HTML, META, TITLE } from "@fartlabs/htx";
+
+export function PageRedirect(props: { to: string }) {
+  return (
+    <HTML>
+      <HEAD>
+        <TITLE>Redirecting to {props.to}</TITLE>
+        <META
+          http-equiv="refresh"
+          content={`0; URL='${props.to}'`}
+        />
+      </HEAD>
+    </HTML>
+  );
+}


### PR DESCRIPTION
### Changes

- Adds component `components/page_redirect.tsx`.
- Add alias `about` to blog post `mission`.
- Generate page redirects for each alias derived from the blog posts.

Resolves #13 